### PR TITLE
[김형준]Add: 선수 비교 chart 구현중

### DIFF
--- a/src/components/charts/player/ChartBar.js
+++ b/src/components/charts/player/ChartBar.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import styled from 'styled-components';
+
+const ChartBar = () => {
+  const data1 = {
+    labels: [
+      '킬 관여율',
+      '가한 피해량 비중',
+      '받은 피해량 비중',
+      '획득 골드 비중',
+      '시야 점수 비중',
+    ],
+    datasets: [
+      {
+        label: 'player1',
+        data: [12, 19, 3, 5, 2],
+        backgroundColor: [
+          'rgb(193, 53, 49)',
+          'rgb(193, 53, 49)',
+          'rgb(193, 53, 49)',
+          'rgb(193, 53, 49)',
+        ],
+        borderWidth: 3,
+      },
+      {
+        label: 'player2',
+        data: [12, 19, 3, 5, 2],
+        backgroundColor: [
+          'rgb(49, 115, 193)',
+          'rgb(49, 115, 193)',
+          'rgb(49, 115, 193)',
+          'rgb(49, 115, 193)',
+        ],
+        borderWidth: 3,
+      },
+      {
+        label: 'player3',
+        data: [12, 19, 3, 5, 2],
+        backgroundColor: [
+          'rgb(119, 154, 52)',
+          'rgb(119, 154, 52)',
+          'rgb(119, 154, 52)',
+          'rgb(119, 154, 52)',
+        ],
+        borderWidth: 3,
+      },
+      {
+        label: 'player4',
+        data: [12, 19, 3, 5, 2],
+        backgroundColor: [
+          'rgb(179, 93, 24)',
+          'rgb(179, 93, 24)',
+          'rgb(179, 93, 24)',
+          'rgb(179, 93, 24)',
+        ],
+        borderWidth: 3,
+      },
+    ],
+  };
+  const options1 = {
+    plugins: {
+      legend: {
+        display: false,
+      },
+      title: {
+        display: true,
+        text: '시즌 평균 팀 내 비중 데이터',
+        color: '#F3F3F3',
+        align: 'start',
+        padding: '15',
+      },
+    },
+    maintainAspectRatio: false,
+    scales: {
+      x: {
+        grid: {
+          color: '#363634',
+          borderColor: '#363634',
+          tickColor: '#363634',
+        },
+        ticks: {
+          fontColor: '#F3F3F3',
+        },
+      },
+      y: {
+        grid: {
+          color: '#363634',
+          borderColor: '#363634',
+          tickColor: '#363634',
+        },
+        ticks: {
+          fontColor: '#F3F3F3',
+        },
+      },
+    },
+  };
+
+  return (
+    <BarLayout>
+      <Bar data={data1} options={options1} />
+    </BarLayout>
+  );
+};
+
+const BarLayout = styled.div`
+  width: 548px;
+  height: 304px;
+  margin: 0 32px 0 32px;
+`;
+
+export default ChartBar;

--- a/src/components/charts/player/ChartBar2.js
+++ b/src/components/charts/player/ChartBar2.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import styled from 'styled-components';
+
+const data2 = {
+  labels: ['가한 피해량', '받은 피해량', '획득골드', '시야 점수'],
+  datasets: [
+    {
+      label: 'player1',
+      data: [12, 19, 3, 5],
+      backgroundColor: [
+        'rgb(193, 53, 49)',
+        'rgb(193, 53, 49)',
+        'rgb(193, 53, 49)',
+        'rgb(193, 53, 49)',
+      ],
+      borderRadius: 2,
+      borderWidth: 3,
+    },
+    {
+      label: 'player2',
+      data: [12, 19, 3, 5],
+      backgroundColor: [
+        'rgb(49, 115, 193)',
+        'rgb(49, 115, 193)',
+        'rgb(49, 115, 193)',
+        'rgb(49, 115, 193)',
+      ],
+      borderRadius: 2,
+      borderWidth: 3,
+    },
+    {
+      label: 'player3',
+      data: [12, 19, 3, 5],
+      backgroundColor: [
+        'rgb(119, 154, 52)',
+        'rgb(119, 154, 52)',
+        'rgb(119, 154, 52)',
+        'rgb(119, 154, 52)',
+      ],
+      borderRadius: 2,
+      borderWidth: 3,
+    },
+    {
+      label: 'player4',
+      data: [12, 19, 3, 5],
+      backgroundColor: [
+        'rgb(179, 93, 24)',
+        'rgb(179, 93, 24)',
+        'rgb(179, 93, 24)',
+        'rgb(179, 93, 24)',
+      ],
+      borderRadius: 2,
+      borderWidth: 3,
+    },
+  ],
+};
+const options2 = {
+  plugins: {
+    legend: {
+      display: false,
+    },
+    title: {
+      display: true,
+      text: '시즌 평균 동일 포지션 대비 데이터',
+      color: '#F3F3F3',
+      align: 'start',
+      padding: '15',
+    },
+  },
+  maintainAspectRatio: false,
+  scales: {
+    x: {
+      grid: {
+        color: '#363634',
+        borderColor: '#363634',
+        tickColor: '#363634',
+      },
+      ticks: {
+        fontColor: '#F3F3F3',
+      },
+    },
+    y: {
+      grid: {
+        color: '#363634',
+        borderColor: '#363634',
+        tickColor: '#363634',
+      },
+      ticks: {
+        fontColor: '#F3F3F3',
+      },
+    },
+  },
+};
+
+const ChartBar2 = () => {
+  return (
+    <BarLayout>
+      <Bar data={data2} options={options2} />
+    </BarLayout>
+  );
+};
+
+const BarLayout = styled.div`
+  width: 548px;
+  height: 304px;
+  margin: 0 32px 0 32px;
+`;
+
+export default ChartBar2;

--- a/src/components/charts/player/ChartBar3.js
+++ b/src/components/charts/player/ChartBar3.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import styled from 'styled-components';
+
+const data3 = {
+  labels: ['시야 점수', '와드 설치', '와드 구매', '와드 제거'],
+  datasets: [
+    {
+      label: 'player1',
+      data: [12, 19, 3, 5],
+      backgroundColor: [
+        'rgb(193, 53, 49)',
+        'rgb(193, 53, 49)',
+        'rgb(193, 53, 49)',
+        'rgb(193, 53, 49)',
+      ],
+      borderRadius: 2,
+      borderWidth: 3,
+    },
+    {
+      label: 'player2',
+      data: [12, 19, 3, 5],
+      backgroundColor: [
+        'rgb(49, 115, 193)',
+        'rgb(49, 115, 193)',
+        'rgb(49, 115, 193)',
+        'rgb(49, 115, 193)',
+      ],
+      borderRadius: 2,
+      borderWidth: 3,
+    },
+    {
+      label: 'player3',
+      data: [12, 19, 3, 5],
+      backgroundColor: [
+        'rgb(119, 154, 52)',
+        'rgb(119, 154, 52)',
+        'rgb(119, 154, 52)',
+        'rgb(119, 154, 52)',
+      ],
+      borderRadius: 2,
+      borderWidth: 3,
+    },
+    {
+      label: 'player4',
+      data: [12, 19, 3, 5],
+      backgroundColor: [
+        'rgb(179, 93, 24)',
+        'rgb(179, 93, 24)',
+        'rgb(179, 93, 24)',
+        'rgb(179, 93, 24)',
+      ],
+      borderRadius: 2,
+      borderWidth: 3,
+    },
+  ],
+};
+const options3 = {
+  plugins: {
+    legend: {
+      display: false,
+    },
+    title: {
+      display: true,
+      text: '시즌 평균 분당 시야 데이터',
+      color: '#F3F3F3',
+      align: 'start',
+      padding: '15',
+    },
+  },
+  maintainAspectRatio: false,
+  scales: {
+    x: {
+      grid: {
+        color: '#363634',
+        borderColor: '#363634',
+        tickColor: '#363634',
+      },
+      ticks: {
+        fontColor: '#F3F3F3',
+      },
+    },
+    y: {
+      grid: {
+        color: '#363634',
+        borderColor: '#363634',
+        tickColor: '#363634',
+      },
+      ticks: {
+        fontColor: '#F3F3F3',
+      },
+    },
+  },
+};
+
+const ChartBar3 = () => {
+  return (
+    <BarLayout>
+      <Bar data={data3} options={options3} />
+    </BarLayout>
+  );
+};
+
+const BarLayout = styled.div`
+  width: 432px;
+  height: 304px;
+`;
+
+export default ChartBar3;

--- a/src/components/charts/player/ChartBar4.js
+++ b/src/components/charts/player/ChartBar4.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import styled from 'styled-components';
+
+const data4 = {
+  labels: [''],
+  datasets: [
+    {
+      label: 'player1',
+      data: [12],
+      backgroundColor: ['rgb(193, 53, 49)'],
+      borderWidth: 5,
+    },
+    {
+      label: 'player2',
+      data: [12],
+      backgroundColor: ['rgb(49, 115, 193)'],
+      borderWidth: 5,
+    },
+    {
+      label: 'player3',
+      data: [12],
+      backgroundColor: ['rgb(119, 154, 52)'],
+      borderWidth: 5,
+    },
+    {
+      label: 'player4',
+      data: [12],
+      backgroundColor: ['rgb(179, 93, 24)'],
+      borderWidth: 5,
+    },
+  ],
+};
+const options4 = {
+  plugins: {
+    legend: {
+      display: false,
+    },
+    title: {
+      display: true,
+      text: '분당 순수 획득 골드',
+      color: '#F3F3F3',
+      align: 'start',
+      padding: '15',
+    },
+  },
+  maintainAspectRatio: false,
+  scales: {
+    x: {
+      grid: {
+        color: '#363634',
+        borderColor: '#363634',
+        tickColor: '#363634',
+      },
+      ticks: {
+        fontColor: '#F3F3F3',
+      },
+    },
+    y: {
+      grid: {
+        color: '#363634',
+        borderColor: '#363634',
+        tickColor: '#363634',
+      },
+      ticks: {
+        fontColor: '#F3F3F3',
+      },
+    },
+  },
+};
+
+const ChartBar4 = () => {
+  return (
+    <BarLayout>
+      <Bar data={data4} options={options4} />
+    </BarLayout>
+  );
+};
+
+const BarLayout = styled.div`
+  width: 200px;
+  height: 304px;
+`;
+
+export default ChartBar4;

--- a/src/components/charts/player/ChartBar5.js
+++ b/src/components/charts/player/ChartBar5.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import styled from 'styled-components';
+
+const data4 = {
+  labels: [''],
+  datasets: [
+    {
+      label: 'player1',
+      data: [12],
+      backgroundColor: ['rgb(193, 53, 49)'],
+      borderWidth: 5,
+    },
+    {
+      label: 'player2',
+      data: [12],
+      backgroundColor: ['rgb(49, 115, 193)'],
+      borderWidth: 5,
+    },
+    {
+      label: 'player3',
+      data: [12],
+      backgroundColor: ['rgb(119, 154, 52)'],
+      borderWidth: 5,
+    },
+    {
+      label: 'player4',
+      data: [12],
+      backgroundColor: ['rgb(179, 93, 24)'],
+      borderWidth: 5,
+    },
+  ],
+};
+const options4 = {
+  plugins: {
+    legend: {
+      display: false,
+    },
+    title: {
+      display: true,
+      text: '분당 CS',
+      color: '#F3F3F3',
+      align: 'start',
+      padding: '15',
+    },
+  },
+  maintainAspectRatio: false,
+  scales: {
+    x: {
+      grid: {
+        color: '#363634',
+        borderColor: '#363634',
+        tickColor: '#363634',
+      },
+      ticks: {
+        fontColor: '#F3F3F3',
+      },
+    },
+    y: {
+      grid: {
+        color: '#363634',
+        borderColor: '#363634',
+        tickColor: '#363634',
+      },
+      ticks: {
+        fontColor: '#F3F3F3',
+      },
+    },
+  },
+};
+
+const ChartBar5 = () => {
+  return (
+    <BarLayout>
+      <Bar data={data4} options={options4} />
+    </BarLayout>
+  );
+};
+
+const BarLayout = styled.div`
+  width: 200px;
+  height: 304px;
+`;
+
+export default ChartBar5;

--- a/src/components/charts/player/ChartBoxplot.js
+++ b/src/components/charts/player/ChartBoxplot.js
@@ -1,0 +1,15 @@
+import react from 'react';
+import styled from 'styled-components';
+
+const ChartBoxplot = () => {
+  return <BoxplotLayout>준비중</BoxplotLayout>;
+};
+
+const BoxplotLayout = styled.div`
+  width: 548px;
+  height: 304px;
+  background: red;
+  margin: 0 32px 0 32px;
+`;
+
+export default ChartBoxplot;

--- a/src/components/charts/player/ChartBubble.js
+++ b/src/components/charts/player/ChartBubble.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import { Bubble } from 'react-chartjs-2';
+import styled from 'styled-components';
+
+const data = {
+  labels: ['Red', 'Blue', 'Yellow'],
+  datasets: [
+    {
+      label: 'My First Dataset',
+      // data: [
+      //   { x: DPG[0].DPM, y: DPG[0].GPM, r: DPG[0].DPG * 20 },
+      //   { x: DPG[1].DPM, y: DPG[1].GPM, r: DPG[1].DPG * 20 },
+      //   { x: DPG[2].DPM, y: DPG[2].GPM, r: DPG[2].DPG },
+      //   { x: DPG[3].DPM, y: DPG[3].GPM, r: DPG[3].DPG },
+      //   { x: DPG[4].DPM, y: DPG[4].GPM, r: DPG[4].DPG },
+      //   { x: DPG[4].DPM, y: DPG[4].GPM, r: DPG[4].DPG },
+      //   { x: DPG[5].DPM, y: DPG[5].GPM, r: DPG[5].DPG },
+      //   { x: DPG[6].DPM, y: DPG[6].GPM, r: DPG[6].DPG },
+      //   { x: DPG[7].DPM, y: DPG[7].GPM, r: DPG[7].DPG },
+      //   { x: DPG[8].DPM, y: DPG[8].GPM, r: DPG[8].DPG },
+      // ],
+      data: [
+        { x: 4, y: 2, r: 10 },
+        { x: 2, y: 6, r: 10 },
+        { x: 1, y: 3, r: 10 },
+      ],
+      backgroundColor: [
+        'rgba(193, 53, 59, .5)',
+        'rgba(49, 115, 193, .5)',
+        'rgba(119, 154, 52, .5)',
+        'rgba(179, 93, 24, .5)',
+      ],
+      borderColor: [
+        'rgb(193, 53, 59)',
+        'rgb(49, 115, 193)',
+        'rgb(119, 154, 52)',
+        'rgb(179, 93, 24)',
+      ],
+    },
+  ],
+};
+
+const options = {
+  maintainAspectRatio: false,
+  scales: {
+    x: {
+      grid: {
+        color: '#363634',
+        borderColor: '#363634',
+        tickColor: '#363634',
+      },
+      title: {
+        display: 'true',
+        text: '골드',
+        size: '10',
+      },
+    },
+    y: {
+      grid: {
+        color: '#363634',
+        borderColor: '#363634',
+        tickColor: '#363634',
+      },
+      title: {
+        display: 'true',
+        text: '가한 피해량',
+        size: '10',
+      },
+    },
+  },
+  plugins: {
+    legend: {
+      display: false,
+    },
+    title: {
+      display: true,
+      text: '골드 당 피해량',
+      color: '#F3F3F3',
+      align: 'start',
+      padding: '15',
+    },
+  },
+};
+
+function ChartBubble() {
+  return (
+    <BubbleLayout>
+      <Bubble type={'bubble'} data={data} options={options} />
+    </BubbleLayout>
+  );
+}
+
+const BubbleLayout = styled.div`
+  width: 432px;
+  height: 304px;
+`;
+
+export default ChartBubble;

--- a/src/components/charts/player/ChartDoughnut.js
+++ b/src/components/charts/player/ChartDoughnut.js
@@ -1,0 +1,202 @@
+import React from 'react';
+import { Doughnut } from 'react-chartjs-2';
+import 'chartjs-plugin-doughnut-innertext';
+import styled from 'styled-components';
+
+const ChartDoughnut = () => {
+  const data1 = {
+    labels: ['Kills', 'Assists', 'Deaths'],
+    datasets: [
+      {
+        label: 'My First Dataset',
+        //data: [props.dpg.KDABox[0].AVGkills, props.dpg.KDABox[0].AVGdeaths, props.dpg.KDABox[0].AVGassists],
+        data: [3.07, 4.53, 1.88],
+        backgroundColor: [
+          'rgb(193, 54, 49)',
+          'rgb(105, 36, 32)',
+          'rgb(203, 92, 88)',
+        ],
+        weight: 10,
+        hoverOffset: 4,
+        cutout: '90%',
+      },
+    ],
+  };
+
+  const valuetext = 'PLAYER 4.04';
+
+  const options1 = {
+    centerText: {
+      color: '#F3F3F3',
+      //value: "KDA : " + props.dpg.KDABox[0].KDA,
+      value: valuetext,
+      fontSizeAdjust: 0.1, // increase font size 20% based on default font size
+    },
+    plugins: {
+      responsive: true,
+      legend: {
+        display: false,
+      },
+    },
+  };
+
+  const data2 = {
+    labels: ['Red', 'Blue', 'Yellow'],
+    datasets: [
+      {
+        label: 'My First Dataset',
+        //data: [props.dpg.KDABox[1].AVGkills, props.dpg.KDABox[1].AVGdeaths, props.dpg.KDABox[1].AVGassists],
+        data: [3.07, 4.53, 1.88],
+        backgroundColor: [
+          'rgb(49, 115, 193)',
+          'rgb(33, 67, 104)',
+          'rgb(88, 141, 203)',
+        ],
+        weight: 10,
+        hoverOffset: 4,
+        cutout: '90%',
+      },
+    ],
+  };
+
+  const options2 = {
+    centerText: {
+      color: '#F3F3F3',
+      //value: "KDA : " + props.dpg.KDABox[1].KDA,
+      value: 'KDA : ' + 4.04,
+      fontSizeAdjust: 0.1, // increase font size 20% based on default font size
+    },
+    plugins: {
+      responsive: true,
+      legend: {
+        display: false,
+      },
+    },
+  };
+
+  const data3 = {
+    labels: ['Red', 'Blue', 'Yellow'],
+    datasets: [
+      {
+        label: 'My First Dataset',
+        //data: [props.dpg.KDABox[2].AVGkills, props.dpg.KDABox[2].AVGdeaths, props.dpg.KDABox[2].AVGassists],
+        data: [3.07, 4.53, 1.88],
+        backgroundColor: [
+          'rgb(247, 125, 28)',
+          'rgb(133, 72, 22)',
+          'rgb(246, 149, 71)',
+        ],
+        weight: 10,
+        hoverOffset: 4,
+        cutout: '90%',
+      },
+    ],
+  };
+
+  const options3 = {
+    centerText: {
+      color: '#000',
+      //value: "KDA : " + props.dpg.KDABox[2].KDA,
+      value: 'KDA : ' + 4.04,
+      fontSizeAdjust: 0.1, // increase font size 20% based on default font size
+    },
+    plugins: {
+      responsive: true,
+      legend: {
+        display: false,
+      },
+    },
+  };
+
+  const data4 = {
+    labels: ['Red', 'Blue', 'Yellow'],
+    datasets: [
+      {
+        label: 'My First Dataset',
+        //data: [props.dpg.KDABox[0].AVGkills, props.dpg.KDABox[0].AVGassists, props.dpg.KDABox[0].AVGdeaths],
+        data: [3.07, 4.53, 1.88],
+        backgroundColor: [
+          'rgb(162, 212, 67)',
+          'rgb(90, 115, 41)',
+          'rgb(178, 218, 102)',
+        ],
+        weight: 10,
+        hoverOffset: 4,
+        cutout: '90%',
+      },
+    ],
+  };
+
+  const options4 = {
+    centerText: {
+      color: '#000',
+      //value: "KDA : " + props.dpg.KDABox[0].KDA,
+      value: 'KDA : ' + 4.04,
+      fontSizeAdjust: 0.1, // increase font size 20% based on default font size
+    },
+    plugins: {
+      responsive: true,
+      legend: {
+        display: false,
+      },
+    },
+  };
+
+  return (
+    <DoughnutLayout>
+      <Doughnut
+        style={firstChart}
+        type={'doughnut'}
+        data={data1}
+        options={options1}
+      />
+      {/* <Doughnut
+        style={secondChart}
+        type={'doughnut'}
+        data={data2}
+        options={options2}
+      />
+      <Doughnut
+        style={thirdChart}
+        type={'doughnut'}
+        data={data3}
+        options={options3}
+      />
+      <Doughnut
+        style={fourthChart}
+        type={'doughnut'}
+        data={data4}
+        options={options4}
+      /> */}
+    </DoughnutLayout>
+  );
+};
+
+const firstChart = {
+  width: '142px',
+  height: '142px',
+  margin: '0 32px 20px 0',
+};
+const secondChart = {
+  width: '142px',
+  height: '142px',
+  margin: '0 0 20px 0',
+};
+const thirdChart = {
+  width: '142px',
+  height: '142px',
+  margin: '0 32px 0 0',
+};
+const fourthChart = {
+  width: '142px',
+  height: '142px',
+};
+
+const DoughnutLayout = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  width: 316px;
+  height: 304px;
+`;
+
+export default ChartDoughnut;

--- a/src/components/charts/player/ChartPolar.js
+++ b/src/components/charts/player/ChartPolar.js
@@ -1,0 +1,65 @@
+import react from 'react';
+import { PolarArea } from 'react-chartjs-2';
+import styled from 'styled-components';
+
+const ChartPolar = () => {
+  const data = {
+    labels: ['player1', 'player2', 'player3', 'player4'],
+    datasets: [
+      {
+        label: 'My First Dataset',
+        data: [11, 16, 7, 3],
+        backgroundColor: [
+          'rgba(193, 53, 49, .3)',
+          'rgba(49, 115, 193, .3)',
+          'rgba(119, 154, 52, .3)',
+          'rgba(179, 93, 24, .3)',
+        ],
+        borderColor: 'rgba(131, 131, 129, 0.1)',
+      },
+    ],
+  };
+
+  const options = {
+    plugins: {
+      responsive: true,
+      legend: {
+        display: false,
+      },
+      title: {
+        display: true,
+        text: '시즌 평균 킬 관여율',
+        color: '#F3F3F3',
+        align: 'start',
+        padding: '15',
+      },
+    },
+    scales: {
+      r: {
+        angleLines: {
+          color: '#363634',
+          lineWidth: 1,
+        },
+        grid: {
+          color: '#363634',
+        },
+        ticks: {
+          display: false,
+        },
+        backgroundColor: 'rgba(131, 131, 129, 0.1)',
+      },
+    },
+  };
+  return (
+    <PolarLayout>
+      <PolarArea data={data} options={options} />
+    </PolarLayout>
+  );
+};
+
+const PolarLayout = styled.div`
+  width: 316px;
+  height: 304px;
+`;
+
+export default ChartPolar;

--- a/src/components/charts/player/LineChart.js
+++ b/src/components/charts/player/LineChart.js
@@ -1,0 +1,90 @@
+import React from "react";
+
+import { Line } from "react-chartjs-2";
+
+const data = {
+  labels: ["W1", "W2", "W3", "W4", "W5", "W6", "W7", "W8", "W9", "W10"],
+  datasets: [
+    {
+      label: "player1",
+      data: [33, 53, 32, 24, 44, 65, 53, 64, 45, 51],
+      fill: false,
+      backgroundColor: "#8D2B27",
+      borderColor: "#8D2B27",
+      pointStyle: 'circle',
+      pointRadius: 3,
+      pointHoverRadius: 5
+    },
+    {
+      label: "player2",
+      data: [33, 53, 32, 24, 44, 65, 86, 57, 48, 39],
+      fill: false,
+      backgroundColor: "#B35D18",
+      borderColor: "#B35D18",
+      pointStyle: 'circle',
+      pointRadius: 3,
+      pointHoverRadius: 5
+    },
+    {
+      label: "player3",
+      data: [33, 53, 32, 24, 44, 65, 20, 59, 86, 23],
+      fill: false,
+      backgroundColor: "#28568C",
+      borderColor: "#28568C",
+      pointStyle: 'circle',
+      pointRadius: 3,
+      pointHoverRadius: 5
+    },
+    {
+      label: "player4",
+      data: [33, 25, 35, 51, 54, 76, 68, 75, 59, 88],
+      fill: false,
+      backgroundColor: "#779A34",
+      borderColor: "#779A34",
+      pointStyle: 'circle',
+      pointRadius: 3,
+      pointHoverRadius: 5
+    }
+  ]
+};
+
+const options = {
+  scales: {
+    x: {
+      grid: {
+        color: '#363634',
+        borderColor: '#363634',
+        tickColor: '#363634'
+      }
+    },
+    y: {
+      grid: {
+        color: '#363634',
+        borderColor: '#363634',
+        tickColor: '#363634'
+      }
+    }
+  },
+  plugins : {
+    legend: {
+      display: false
+    },
+    title: {
+      display: true,
+      text: '주차별 분 당 가한 피해량',
+      color: '#F3F3F3',
+      align: 'start',
+      padding: '15'
+    }
+  }
+}
+
+const LineChart = () => {
+  return (
+    <div>
+      <Line data={data} options={options} />
+    </div>
+  );
+}
+
+export default LineChart;

--- a/src/components/charts/player/RadarChart.js
+++ b/src/components/charts/player/RadarChart.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Radar } from 'react-chartjs-2';
+import styled from 'styled-components';
+
+const RadarChart = () => {
+  const data = {
+    labels: ['골드 수급력', '생존력', '시야장악력', '전투력'],
+    datasets: [
+      {
+        label: 'Player1',
+        backgroundColor: 'rgba(193, 53, 49, .3)',
+        borderColor: '#C13631',
+        pointBackgroundColor: '#C13631',
+        poingBorderColor: '#fff',
+        pointHoverBackgroundColor: '#fff',
+        pointHoverBorderColor: '#C13631',
+        data: [6.98, 3.2, 3.4, 3.6],
+      },
+      {
+        label: 'Player2',
+        backgroundColor: 'rgba(49, 115, 193, .3)',
+        borderColor: '#3173C1',
+        pointBackgroundColor: '#3173C1',
+        poingBorderColor: '#fff',
+        pointHoverBackgroundColor: '#fff',
+        pointHoverBorderColor: '#3173C1',
+        data: [6.92, 2.2, 2.6, 4.3],
+      },
+      {
+        label: 'Player3',
+        backgroundColor: 'rgba(119, 154, 52, .3)',
+        borderColor: '#779A34',
+        pointBackgroundColor: '#779A34',
+        poingBorderColor: '#fff',
+        pointHoverBackgroundColor: '#fff',
+        pointHoverBorderColor: '#779A34',
+        data: [7.16, 3.6, 3.9, 2.3],
+      },
+      {
+        label: 'Player4',
+        backgroundColor: 'rgba(179, 93, 24, .3)',
+        borderColor: '#B35D18',
+        pointBackgroundColor: '#B35D18',
+        poingBorderColor: '#fff',
+        pointHoverBackgroundColor: '#fff',
+        pointHoverBorderColor: '#B35D18',
+        data: [6.87, 4.3, 3.5, 3.0],
+      },
+    ],
+  };
+
+  const options = {
+    plugins: {
+      legend: {
+        display: false,
+      },
+    },
+    scales: {
+      r: {
+        angleLines: {
+          color: '#363634',
+          lineWidth: 1,
+        },
+        grid: {
+          color: '#363634',
+        },
+        ticks: {
+          display: false,
+        },
+        backgroundColor: 'rgba(131, 131, 129, 0.1)',
+      },
+    },
+  };
+  return (
+    <RadarLayout>
+      <Radar data={data} options={options} />
+    </RadarLayout>
+  );
+};
+
+const RadarLayout = styled.div`
+  width: 316px;
+  height: 304px;
+`;
+
+export default RadarChart;


### PR DESCRIPTION
## :: 최근 작업 주제

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 선수 비교 chart 구현

<br />

## :: 구현 사항 설명

1. 선수 비교 차트 UI 구현

- 시즌 평균 분당 시야 데이터(Bar Chart)
- 시즌 평균 팀 내 비중 데이터(Bar Chart)
- 매치별 골드당 데미지(Bubble Chart)
- 시즌 평균 킬 관여율(Polar Chart)
- 시즌 평균 동일 포지션 대비 데이터(Bar Chart)
- 분당 순수 획득 골드(Bar Chart)
- 분당 CS(Bar Chart)
- KDA(Doughnut Chart)
- Radar Chart
